### PR TITLE
Removed dependency on Hashie

### DIFF
--- a/lib/tumblife/api.rb
+++ b/lib/tumblife/api.rb
@@ -2,7 +2,6 @@
 
 require 'oauth'
 require 'json'
-require 'hashie'
 
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/hash/keys'
@@ -49,12 +48,12 @@ module Tumblife
     end
 
     def parse_response(res)
-      json = Hashie::Mash.new(JSON.parse(res.body))
-      case json.meta.status.to_i
+      json = JSON.parse(res.body)
+      case json['meta']['status'].to_i
       when 400...600
-        raise APIError.new(json.meta.msg, res)
+        raise APIError.new(json['meta']['msg'], res)
       else
-        json.response
+        json['response']
       end
     end
   end

--- a/lib/tumblife/client.rb
+++ b/lib/tumblife/client.rb
@@ -2,7 +2,6 @@
 
 require 'oauth'
 require 'json'
-require 'hashie'
 require 'cgi'
 
 module Tumblife

--- a/spec/tumblife/api_spec.rb
+++ b/spec/tumblife/api_spec.rb
@@ -4,15 +4,15 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Tumblife::API do
   def create_response(status, msg)
-    Hashie::Mash.new({
-      :body => {
-        :meta => {
-          :status => status,
-          :msg => msg
-        },
-        :response => {}
-      }.to_json
-    })
+    mock_response = double("response")
+    mock_response.stub(:body).and_return({
+      'meta' => {
+        'status' => status,
+        'msg' => msg
+      },
+      'response' => {}
+    }.to_json)
+    return mock_response
   end
 
   before do

--- a/tumblife.gemspec
+++ b/tumblife.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "tumblife"
   s.add_runtime_dependency("oauth", "~> 0.4.5")
   s.add_runtime_dependency("json", "~> 1.6.4") if RUBY_VERSION < "1.9"
-  s.add_runtime_dependency("hashie", "~> 1.2.0")
   s.add_runtime_dependency("activesupport", "~> 3.1.3")
   s.add_development_dependency("rspec", "~> 2.8.0")
+  s.add_development_dependency("rake", "~> 0.9.2.2")
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
I don't really like Hashie, and it caused issues when I tried to extract the raw Hash out of the returned Hashie instance, due to a Hashie bug when calling to_hash on nested arrays.
