### PR TITLE
Change dependency versions

### DIFF
--- a/tumblife.gemspec
+++ b/tumblife.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.description = %q{Tumblife is a simple Tumblr API v2 library.}
 
   s.rubyforge_project = "tumblife"
-  s.add_runtime_dependency("oauth", "~> 0.4.6")
-  s.add_runtime_dependency("json", "~> 1.6.6") if RUBY_VERSION < "1.9"
-  s.add_runtime_dependency("hashie", "~> 1.2.0")
+  s.add_runtime_dependency("oauth", "> 0.4.6")
+  s.add_runtime_dependency("json", "> 1.6.6") if RUBY_VERSION < "1.9"
+  s.add_runtime_dependency("hashie", "> 1.2.0")
   s.add_runtime_dependency("activesupport", "> 3.0.0")
   s.add_development_dependency("rspec", "~> 2.9.0")
 

--- a/tumblife.gemspec
+++ b/tumblife.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |s|
   s.description = %q{Tumblife is a simple Tumblr API v2 library.}
 
   s.rubyforge_project = "tumblife"
-  s.add_runtime_dependency("oauth", "> 0.4.6")
-  s.add_runtime_dependency("json", "> 1.6.6") if RUBY_VERSION < "1.9"
-  s.add_runtime_dependency("hashie", "> 1.2.0")
-  s.add_runtime_dependency("activesupport", "> 3.0.0")
+  s.add_runtime_dependency("oauth", ">= 0.4.6")
+  s.add_runtime_dependency("json", ">= 1.6.6") if RUBY_VERSION < "1.9"
+  s.add_runtime_dependency("hashie", ">= 1.2.0")
+  s.add_runtime_dependency("activesupport", ">= 3.0.0")
   s.add_development_dependency("rspec", "~> 2.9.0")
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
I changed dependency versions because with rails 3.2.3, bundler dependency failed.

```
Bundler could not find compatible versions for gem "json":
  In Gemfile:
    tumblife (~> 1.0.0) ruby depends on
      json (~> 1.6.6) ruby

    rails (= 3.2.3) ruby depends on
      json (1.7.1)
```
