### PR TITLE
Bump simple_oauth dependency version to ~> 0.2.0

### DIFF
--- a/tumblife.gemspec
+++ b/tumblife.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'faraday', '~> 0.8.0'
   s.add_runtime_dependency 'faraday_middleware', '~> 0.8.7'
   s.add_runtime_dependency 'multi_json', '~> 1.3.5'
-  s.add_runtime_dependency 'simple_oauth', '~> 0.1.8'
+  s.add_runtime_dependency 'simple_oauth', '~> 0.2.0'
   s.add_runtime_dependency 'hashie', '~> 1.2.0'
   s.add_development_dependency 'json'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
No significant changes have been made to simple_oauth since 0.1.9, as you can easily see at https://github.com/laserlemon/simple_oauth/commits/v0.2.0

This change should have no effect other than conflict resolution with other gems that require simple_oauth 0.2.0 or higher. This became an issue for me because I want to use tumblife as well as the twitter gem which requires simple_oauth ~> 0.2.
